### PR TITLE
Switch master to main in tests. ref #14

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,10 +6,10 @@ name: run-tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
Minor change to reference the (new) main branch, rather than master, in the github workflow.