### PR TITLE
Update content to reflect move from mit-lcp to wfdb (ref #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This repository contains a Jupyter book called 'MIMIC WFDB Tutorials', which presents tutorials on using the MIMIC Waveform Database for Biomedical Signal Processing.
 
-The book is available [here](https://mit-lcp.github.io/mimic_wfdb_tutorials/).
+The book is available [here](https://wfdb.github.io/mimic_wfdb_tutorials/intro.html).
 
 ## Contributors ✨
 

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -23,7 +23,7 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/mit-lcp/mimic_wfdb_tutorials  # Online location of your book
+  url: https://github.com/wfdb/mimic_wfdb_tutorials  # Online location of your book
   branch: main  # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book

--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,6 @@
 About this Book
 =======================
 
-- [Contributors](https://github.com/MIT-LCP/mimic_wfdb_tutorials#contributors-)
+- [Contributors](https://github.com/wfdb/mimic_wfdb_tutorials#contributors-)
 - [How to contribute](./about/about-contributing)
 - [Maintenance](./about/about-maintenance)

--- a/content/about/about-maintenance.md
+++ b/content/about/about-maintenance.md
@@ -10,7 +10,7 @@ There are two ways to edit the book:
 ```{dropdown} **2. Edit on a local computer:** Only open to project administrators
 - Clone the repository
 
-`cd /Users/petercharlton/Documents/GitHub/; git clone https://github.com/mit-lcp/mimic_wfdb_tutorials`
+`cd /Users/petercharlton/Documents/GitHub/; git clone https://github.com/wfdb/mimic_wfdb_tutorials`
 - Make edits to the files on a local computer.
 - Upload the files through a git push (as detailed [here](https://jupyterbook.org/start/publish.html#create-an-online-repository-for-your-book)):
 


### PR DESCRIPTION
There are several links that need to be updated to reflect the move from the MIT-LCP organisation to the WFDB organisation (see: https://github.com/wfdb/mimic_wfdb_tutorials/issues/4).

This pull request updates links in the readme, content, and configuration. The old MIT-LCP links also appear in the content/_build directory. I have not updated these manually, because they should be updated when the book is rebuilt.

