### PR TITLE
Add wfdb to requirements. fixes #17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Jinja2==3.0.3
 jupyter-book==0.9.1
 matplotlib==3.5.2
 numpy>=1.10
+wfdb==3.4.1


### PR DESCRIPTION
The WFDB package is a dependency of the book. Building the book with `jupyter-book build --all content` currently raises the following error:

```
------------------
# setup
import sys
import wfdb
------------------

---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Input In [1], in <cell line: 3>()
      1 # setup
      2 import sys
----> 3 import wfdb

ModuleNotFoundError: No module named 'wfdb'
ModuleNotFoundError: No module named 'wfdb'
```

This pull request adds the WFDB dependency to requirements.txt. Fixes https://github.com/wfdb/mimic_wfdb_tutorials/issues/17.

