### PR TITLE
Ignore the build directory. Ref #19.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # MACOS DS_Store
 .DS_Store
+
+# Jupyter Book build directory
+_build/


### PR DESCRIPTION
Minor change to add the `_build` directory to gitignore. I don't think we want to track this folder in the repo (see #19). The _build directory will be automatically created on the `gh-pages` branch by https://github.com/wfdb/mimic_wfdb_tutorials/pull/24.