### PR TITLE
Fix build path on deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     # Build the book
     - name: Build the book
       run: |
-        jupyter book build content --all
+        jupyter book build content --all --path-output ./
 
     # Push the book's HTML to github-pages
     - name: GitHub Pages action


### PR DESCRIPTION
We added a github workflow in https://github.com/wfdb/mimic_wfdb_tutorials/pull/24 that builds the book on the gh-pages branch (which is then served at: https://wfdb.io/mimic_wfdb_tutorials/intro.html).

The current script adds the build output to a `content` subfolder: 
https://github.com/wfdb/mimic_wfdb_tutorials/tree/gh-pages

We want the build output to appear in the root of the gh-pages branch. I think this pull request should do that.