### PR TITLE
Minor correction. Rebuild fix image build issue?

### DIFF
--- a/content/mimic/physionet.md
+++ b/content/mimic/physionet.md
@@ -53,9 +53,9 @@ _Source: [Springer Nature](https://www.springernature.com/gp/authors/research-da
 
 - Data such as waveforms can be viewed directly in the browser
 
----
-
 ![](../images/lightwave.png)
+
+---
 
 # Cloud integration
 


### PR DESCRIPTION
This moves one of the divider lines on the MIMIC pages. 

The last build did not render images that are showing on my local build. Hoping that a rebuild will fix the issue but if not I'll raise an issue for this. 