### PR TITLE
Fix links to workshop content

### DIFF
--- a/content/_toc.yml
+++ b/content/_toc.yml
@@ -4,10 +4,10 @@
 - file: intro
 - file: workshop
   sections:
-    - file: workshop/workshop-aims
-    - file: workshop/workshop-synopsis
-    - file: workshop/workshop-schedule
-    - file: workshop/workshop-prep
+    - file: workshop/aims
+    - file: workshop/synopsis
+    - file: workshop/schedule
+    - file: workshop/prep
 - file: mimic-database
   sections:
     - file: mimic/physionet


### PR DESCRIPTION
In https://github.com/wfdb/mimic_wfdb_tutorials/pull/81 we cleaned up the paths to workshop content (to avoid repeated "workshop" in the urls).

https://github.com/wfdb/mimic_wfdb_tutorials/commit/c589fd6178cd63b4187da0827dfe766c61c0260a reverted back to older links in the toc.

This pull request updates the toc to use the new locations again.
