### PR TITLE
Update data-exploration.ipynb (Mismatch in printed segment)

### DIFF
--- a/content/tutorial/notebooks/data-exploration.ipynb
+++ b/content/tutorial/notebooks/data-exploration.ipynb
@@ -598,7 +598,7 @@
         "segment_metadata = wfdb.rdheader(record_name=segments[2], pn_dir=record_dir)\n",
         "\n",
         "print(f\"\"\"Header metadata loaded for: \n",
-        "- the segment '{segments[1]}'\n",
+        "- the segment '{segments[2]}'\n",
         "- in record '{record_name}'\n",
         "- for subject '{str(Path(record_dir).parent.parts[-1])}'\n",
         "\"\"\")"


### PR DESCRIPTION
`segment_metadata` accesses 83411188_0002 instead of 83411188_0001 (as stated by the `- the segment '{segments[1]}'` , thus changed the print statement to `- the segment '{segments[2]}'`. (This was confusing for my when trying the exercize "Which of these signals is no longer present in segment '83411188_0005'?")