### PR TITLE
Bump Jupyter-Notebook and dependencies to fix build error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
   deploy-book:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Install dependencies
     - name: Set up Python 3.9

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
     - uses: actions/checkout@v4
 
     # Install dependencies
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
       # Checkout the latest code from the repo
       # https://github.com/actions/checkout
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Setup which version of Python to use
       # https://github.com/actions/setup-python
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.10"]
     steps:
       # Checkout the latest code from the repo
       # https://github.com/actions/checkout
@@ -26,7 +26,7 @@ jobs:
       # Setup which version of Python to use
       # https://github.com/actions/setup-python
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       # Display the Python version being used

--- a/content/_toc.yml
+++ b/content/_toc.yml
@@ -1,40 +1,39 @@
-# Table of content
-# Learn more at https://jupyterbook.org/customize/toc.html
-#
-- file: intro
+format: jb-article
+root: intro
+sections:
 - file: workshop
   sections:
-    - file: workshop/aims
-    - file: workshop/synopsis
-    - file: workshop/schedule
-    - file: workshop/prep
+  - file: workshop/aims
+  - file: workshop/synopsis
+  - file: workshop/schedule
+  - file: workshop/prep
 - file: mimic-database
   sections:
-    - file: mimic/physionet
-    - file: mimic/context
-    - file: mimic/structure
-    - file: mimic/formatting
-    - file: mimic/wfdb-toolbox
+  - file: mimic/physionet
+  - file: mimic/context
+  - file: mimic/structure
+  - file: mimic/formatting
+  - file: mimic/wfdb-toolbox
 - file: tutorials
   sections:
-    - file: tutorial/notebooks/data-exploration
-    - file: tutorial/notebooks/data-extraction
-    - file: tutorial/notebooks/data-visualisation
-    - file: tutorial/notebooks/signal-filtering
-    - file: tutorial/notebooks/differentiation
-    - file: tutorial/notebooks/beat-detection
-    - file: tutorial/notebooks/pulse-wave-analysis
-    - file: tutorial/notebooks/extracting-reference-bp
+  - file: tutorial/notebooks/data-exploration
+  - file: tutorial/notebooks/data-extraction
+  - file: tutorial/notebooks/data-visualisation
+  - file: tutorial/notebooks/signal-filtering
+  - file: tutorial/notebooks/differentiation
+  - file: tutorial/notebooks/beat-detection
+  - file: tutorial/notebooks/pulse-wave-analysis
+  - file: tutorial/notebooks/extracting-reference-bp
 - file: case-study
 - file: additional-resources
 - file: about
   sections:
-    - file: about/about-contributing
-    - file: about/about-maintenance
+  - file: about/about-contributing
+  - file: about/about-maintenance
 - file: tutorials-for-the-future
   sections:
-    - file: tutorial/notebooks/qrs-detection
-    - file: tutorial/signal-quality-assessment
-    - file: tutorial/data-modelling
-    - file: tutorial/data-analysis
-    - file: tutorial/data-interpretation
+  - file: tutorial/notebooks/qrs-detection
+  - file: tutorial/signal-quality-assessment
+  - file: tutorial/data-modelling
+  - file: tutorial/data-analysis
+  - file: tutorial/data-interpretation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Jinja2==3.0.3
-jupyter-book==0.9.1
+Jinja2==3.1.4
+jupyter-book==1.0.2
 matplotlib==3.5.2
-numpy>=1.10
+numpy>=1.23.1
 wfdb==3.4.1


### PR DESCRIPTION
As discussed in https://github.com/wfdb/mimic_wfdb_tutorials/issues/89, the website build is currently failing with a "Sphinx version error":

```
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/sphinx/registry.py", line 430, in load_extension
    metadata = setup(app)
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/sphinxcontrib/applehelp/__init__.py", line 230, in setup
    app.require_sphinx('5.0')
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/sphinx/application.py", line 415, in require_sphinx
    raise VersionRequirementError(version)
sphinx.errors.VersionRequirementError: 5.0
```

This pull request bump Jupyter-Notebook and dependencies to fix the build error.
